### PR TITLE
Fix links to typedb-examples fixed after domain-based restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ data in one single place.
 
 ## Example projects
 
-- [`TypeDB Examples - Catalogue of Life`](https://github.com/vaticle/typedb-examples/tree/master/catalogue_of_life) - Catalogue of Life is a database of over 4.5 million currently known taxa in biology, compiled from over a hundred different sources. 
+- [`TypeDB Examples - Catalogue of Life`](https://github.com/vaticle/typedb-examples/tree/master/biology/catalogue_of_life) - Catalogue of Life is a database of over 4.5 million currently known taxa in biology, compiled from over a hundred different sources. 
 TypeDB Loader loads this enormous dataset in so we can elegantly query it with rule-based inference TypeQL queries.
-- [`TypeDB Examples - XCOM`](https://github.com/vaticle/typedb-examples/tree/master/xcom) - XCOM 2 is a massive sci-fi strategy game where humanity must respond to a growing alien threat. Explore data about the XCOM 2 technology tree using TypeDB and TypeQL.
-- [`TypeDB Examples - GitHub`](https://github.com/vaticle/typedb-examples/tree/master/github) - GitHub, the site you're on right now, is a vast pool of heavily interconnected data. See this example that integrates TypeDB and TypeQL into a GUI.
+- [`TypeDB Examples - XCOM`](https://github.com/vaticle/typedb-examples/tree/master/gaming/xcom) - XCOM 2 is a massive sci-fi strategy game where humanity must respond to a growing alien threat. Explore data about the XCOM 2 technology tree using TypeDB and TypeQL.
+- [`TypeDB Examples - GitHub`](https://github.com/vaticle/typedb-examples/tree/master/software/github) - GitHub, the site you're on right now, is a vast pool of heavily interconnected data. See this example that integrates TypeDB and TypeQL into a GUI.
 
 ## Blog posts
 


### PR DESCRIPTION
## What is the goal of this PR?

We fix the links to typedb-examples after restructuring the repository so that projects belong to domains.

## What are the changes implemented in this PR?

The domain folder name is inserted into the path so that the links function correctly.
